### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ This is an example pet name generator app used in the OpenAI API [quickstart tut
 
 5. Make a copy of the example environment variables file
 
+   On Linux systems: 
    ```bash
    $ cp .env.example .env
    ```
-
+   On Windows:
+   ```powershell
+   $ copy .env.example .env
+   ```
 6. Add your [API key](https://beta.openai.com/account/api-keys) to the newly created `.env` file
 
 7. Run the app


### PR DESCRIPTION
`cp` is not supported on the windows command prompt. I've added `copy` instead.