### PR TITLE
Move error handling to before attempting to interpret json response

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -17,11 +17,11 @@ export default function Home() {
         body: JSON.stringify({ animal: animalInput }),
       });
 
-      const data = await response.json();
       if (response.status !== 200) {
-        throw data.error || new Error(`Request failed with status ${response.status}`);
+        throw new Error(`Request failed with status ${response.status}`);
       }
 
+      const data = await response.json();
       setResult(data.result);
       setAnimalInput("");
     } catch(error) {


### PR DESCRIPTION
Community post of affected users here: https://community.openai.com/t/api-504s-in-production-vercel-only/28795

Vercel users are currently experiencing a timeout issue with OpenAI's API, however, it is not clear the issue is a timeout due to the way [error handling has been setup in the quickstart project](https://community.openai.com/t/api-504s-in-production-vercel-only/28795).

Currently the sample project's fetch completion handler is trying to interpret a json response from an error string. This leads to an unclear error. 
`Uncaught (in promise) SyntaxError: Unexpected token 'A', "An error o"... is not valid JSON`

The error handling would be more reliable if we reported on the status rather than assuming we will always get a json response.

See the full investigation and resolution in the post linked above.